### PR TITLE
Fix broken links and typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,14 +16,14 @@
     <!-- HEADER -->
     <div id="header_wrap" class="outer">
         <header class="inner">
-          <a id="forkme_banner" href="https://github.com/theratpack/grails-zap-security-tests">View on GitHub</a>
+          <a id="forkme_banner" href="https://github.com/theratpack/grails-zap-security-tests-plugin">View on GitHub</a>
 
           <h1 id="project_title">Grails ZAP Security Tests Plugin</h1>
-          <h2 id="project_tagline">Automated security tests using the OWASP Zed Attach Proxy</h2>
+          <h2 id="project_tagline">Automated security tests using the OWASP Zed Attack Proxy</h2>
 
             <section id="downloads">
-              <a class="zip_download_link" href="https://github.com/theratpack/grails-zap-security-tests/zipball/master">Download this project as a .zip file</a>
-              <a class="tar_download_link" href="https://github.com/theratpack/grails-zap-security-tests/tarball/master">Download this project as a tar.gz file</a>
+              <a class="zip_download_link" href="https://github.com/theratpack/grails-zap-security-tests-plugin/zipball/master">Download this project as a .zip file</a>
+              <a class="tar_download_link" href="https://github.com/theratpack/grails-zap-security-tests-plugin/tarball/master">Download this project as a tar.gz file</a>
             </section>
         </header>
     </div>


### PR DESCRIPTION
Fix broken links "View on GitHub" and "Download this project as a..." by
adding the missing "-plugin" in the repo name.
Fix typo in "project_tagline", "Attack" instead of "Attach".
